### PR TITLE
Issue#12

### DIFF
--- a/data/verifier-config.json
+++ b/data/verifier-config.json
@@ -1,0 +1,39 @@
+{
+    "client_id": "https://dss.aegean.gr",
+    "client_name": "UAegean EWC Verifier",
+    "redirect_uris": [
+      "https://example-verifier.com/callback"
+    ],
+    "vp_formats_supported": [
+      "jwt_vc_json",
+      "ldp_vc"
+    ],
+    "vp_token_endpoint_auth_methods_supported": [
+      "client_secret_basic",
+      "client_secret_post"
+    ],
+    "presentation_definition_uri": "https://example-verifier.com/presentation-definitions",
+    "scopes_supported": [
+      "openid",
+      "profile",
+      "vc_present"
+    ],
+    "response_types_supported": [
+      "vp_token"
+    ],
+    "grant_types_supported": [
+      "authorization_code"
+    ],
+    "id_token_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "vp_token_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "subject_types_supported": [
+      "pairwise"
+    ]
+  }
+  

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "SERVER_URL=https://95cf-2a02-587-8713-1c00-7651-758f-5657-ed40.ngrok-free.app node server.js"
+    "dev": "SERVER_URL=https://dd0d-2a02-587-8713-1c00-f2ea-680b-e09-62ed.ngrok-free.app node server.js"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "SERVER_URL=https://2131-2a02-587-870a-9d00-82cc-e03d-e6be-d2f8.ngrok-free.app node server.js"
+    "dev": "SERVER_URL=https://95cf-2a02-587-8713-1c00-7651-758f-5657-ed40.ngrok-free.app node server.js"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "SERVER_URL=https://fb13-2a02-587-870a-9d00-812c-35df-3c2a-93f4.ngrok-free.app node server.js"
+    "dev": "SERVER_URL=https://2131-2a02-587-870a-9d00-82cc-e03d-e6be-d2f8.ngrok-free.app node server.js"
   },
   "author": "",
   "license": "ISC",

--- a/routes/verifierRoutes.js
+++ b/routes/verifierRoutes.js
@@ -57,6 +57,9 @@ const presentation_definition_alliance_and_education_Id = JSON.parse(
   )
 );
 //
+const clientMetadata = JSON.parse(
+  fs.readFileSync("./data/verifier-config.json", "utf-8")
+);
 
 const jwks = pemToJWK(publicKeyPem, "public");
 
@@ -221,8 +224,36 @@ verifierRouter.get("/vpRequestJwt/:id", async (req, res) => {
     serverURL,
     privateKey
   );
-  res.type("text/plain").send(jwtToken);
+
+
+  clientMetadata.presentation_definition_uri= serverURL+"/presentation-definition/1"
+
+   let vpRequest= {
+    response_type: "vp_token",
+    client_id: clientId,
+    client_id_scheme: "redirect_uri",
+    presentation_definition: presentation_definition_jwt,
+    redirect_uri: response_uri,
+    // response_mode: "direct_post",
+    client_metadata : encodeURIComponent(JSON.stringify(clientMetadata)),
+   }
+
+   console.log("will send vpRequest")
+   console.log(vpRequest)
+
+   res.json(vpRequest);
 });
+
+
+verifierRouter.get("/presentation-definition/:type", async (req, res) => {
+  const { type } = req.params;
+  if(type == 1) {
+    res.type("application/json").send(presentation_definition_jwt);
+  }
+  console.log("ERROR getting presentatiton-definition type")
+  res.status(500)
+})
+
 
 // *******************PILOT USE CASES ******************************
 verifierRouter.get("/vp-request/:type", async (req, res) => {

--- a/routes/verifierRoutes.js
+++ b/routes/verifierRoutes.js
@@ -214,19 +214,21 @@ verifierRouter.get("/vpRequestJwt/:id", async (req, res) => {
     claims: null,
   });
 
-  let jwtToken = buildVpRequestJwt(
-    stateParam,
-    nonce,
-    clientId,
-    response_uri,
-    presentation_definition_jwt,
-    jwks,
-    serverURL,
-    privateKey
-  );
+  // let jwtToken = buildVpRequestJwt(
+  //   stateParam,
+  //   nonce,
+  //   clientId,
+  //   response_uri,
+  //   presentation_definition_jwt,
+  //   jwks,
+  //   serverURL,
+  //   privateKey
+  // );
 
 
   clientMetadata.presentation_definition_uri= serverURL+"/presentation-definition/1"
+  clientMetadata.redirect_uris= [response_uri]
+  clientMetadata.client_id=clientId
 
    let vpRequest= {
     response_type: "vp_token",

--- a/utils/cryptoUtils.js
+++ b/utils/cryptoUtils.js
@@ -49,49 +49,52 @@ export function buildVpRequestJwt(
 */
 
   /**
- * response_uri
- * client_id_scheme: "redirect_uri",
- * iss": "https://some.io",
- * presentation_definition: {}
- * "response_type": "vp_token",
-  "state": "344306f6-0323-4ef5-9348-70fc328efd85",
-  "exp": 1712309984,
-  "nonce": "1fRxngVjYq0oETeZxNYfId",
-  "iat": 1712306384,
-  "client_id": "https://some.io/openid4vp/authorization-response",
-  "response_mode": "direct_post"
+ Location: https://client.example.org/universal-link?
+    response_type=vp_token
+    &client_id=https%3A%2F%2Fclient.example.org%2Fcb
+    &client_id_scheme=redirect_uri
+    &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &presentation_definition=...
+    &nonce=n-0S6_WzA2Mj
+    &client_metadata=%7B%22vp_formats%22:%7B%22jwt_vp%22:%
+    7B%22alg%22:%5B%22EdDSA%22,%22ES256K%22%5D%7D,%22ldp
+    _vp%22:%7B%22proof_type%22:%5B%22Ed25519Signature201
+    8%22%5D%7D%7D%7D
  * 
  */
 
   let jwtPayload = {
-    client_id_scheme: "redirect_uri",
-    response_uri: response_uri, //TODO Note: If the Client Identifier scheme redirect_uri is used in conjunction with the Response Mode direct_post, and the response_uri parameter is present, the client_id value MUST be equal to the response_uri value
-    iss: serverURL,
-    presentation_definition: presentation_definition,
     response_type: "vp_token",
-    state: state,
-    exp: Math.floor(Date.now() / 1000) + 60,
-    nonce: nonce,
-    iat: Math.floor(Date.now() / 1000),
     client_id: client_id,
-    response_mode: "direct_post",
+    client_id_scheme: "redirect_uri",
+    presentation_definition: presentation_definition,
+    redirect_uri: response_uri,
+    // response_mode: "direct_post",
+    client_metadata : "",
+    
+    // response_uri: response_uri, //TODO Note: If the Client Identifier scheme redirect_uri is used in conjunction with the Response Mode direct_post, and the response_uri parameter is present, the client_id value MUST be equal to the response_uri value
+    // iss: serverURL,
+    // state: state,
+    // exp: Math.floor(Date.now() / 1000) + 60,
+    // nonce: nonce,
+    // iat: Math.floor(Date.now() / 1000),
     // nbf: Math.floor(Date.now() / 1000),
     // redirect_uri: redirect_uri,
     // scope: "openid",
     
   };
 
-  const header = {
-    alg: "ES256",
-    kid: `aegean#authentication-key`, //this kid needs to be resolvable from the did.json endpoint
-  };
+  // const header = {
+  //   alg: "ES256",
+  //   kid: `aegean#authentication-key`, //this kid needs to be resolvable from the did.json endpoint
+  // };
 
-  const token = jwt.sign(jwtPayload, privateKey, {
-    algorithm: "ES256",
-    noTimestamp: true,
-    header,
-  });
-  return token;
+  // const token = jwt.sign(jwtPayload, privateKey, {
+  //   algorithm: "ES256",
+  //   noTimestamp: true,
+  //   header,
+  // });
+  return jwtPayload;
 }
 
 export async function decryptJWE(jweToken, privateKeyPEM) {


### PR DESCRIPTION
Based on [issue#12 ](https://github.com/EWC-consortium/ewc-wallet-conformance-backend/issues/12) changed vp authorization request, to a plain json from jwt  using response_uri instead of redirect_uri with with direct_post.  Since we are using direct_post and this makes the use of response_uri mandatory (instead of redirect_uri)